### PR TITLE
Couple small changes to browserify.c

### DIFF
--- a/browserify.c
+++ b/browserify.c
@@ -6,6 +6,12 @@ int main(int argc, const char *argv[])
 	unsigned int state;
 	unsigned short data;
 
+	if (argc != 2)
+	{
+		fprintf(stderr, "Usage: %s input-file\n", argv[0]);
+		return 255;
+	}
+	
 	if ((file = fopen(argv[1], "rb")) == NULL)
 	{
 		perror("fopen");

--- a/browserify.c
+++ b/browserify.c
@@ -20,7 +20,7 @@ int main(int argc, const char *argv[])
 
 	while (fread(&data, 2, 1, file) == 1)
 	{
-		fprintf(stdout, "\\u%04x", data);
+		printf("\\u%04x", data);
 	}
 	fclose(file);
 	return 0;


### PR DESCRIPTION
I noticed you forgot to add an arg check to browserify.c. I also noticed you typed `fprintf(stdout,` somewhere; I replaced this with `printf` because (AFAIK) that's convention, and it works the same. Output will still be redirected. It's not like `fputs` vs `puts` where the latter adds a newline and the former doesn't; the behavior is equivalent.

Also thanks for your efforts in reverse engineering exploits and _actually making it public!_ :smile: 
